### PR TITLE
Change Fatal termination to Error. File .env not indispensable.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 
 	if err := godotenv.Load(); err != nil {
-		logrus.Fatalf("error loading env variables: %s", err.Error())
+		logrus.Errorf("error loading env variables: %s", err.Error())
 	}
 
 	db, err := repository.NewPostgresDB(repository.Config{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,10 @@ func main() {
 		logrus.Errorf("error loading env variables: %s", err.Error())
 	}
 
+	if "" == os.Getenv("DB_PASSWORD") {
+		logrus.Fatalf("error cannot initializing database password")
+	}
+
 	db, err := repository.NewPostgresDB(repository.Config{
 		Host:     viper.GetString("db.host"),
 		Port:     viper.GetString("db.port"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   todo-app:
     build: ./
-    command: ./wait-for-postgres.sh db ./todo-app
+    command: sh -c "./wait-for-postgres.sh db; /todo-app"
     ports:
       - 8000:8000
     depends_on:


### PR DESCRIPTION
При запуске docker-контейнера с приложением, если нет .env файла, приложение завершается с фатальным логом. Но переменную DB_PASSWORD можно передать в контейнер используя docker-compose. Думаю правильнее завершаться в том случае, если переманная DB_PASSWORD пустая. А при отсутствии .env файла, сообщать об этом в лог.
 